### PR TITLE
クエリストリングを設定してIDをキーとした検索条件を追加する

### DIFF
--- a/src/main/java/com/eight/mybatistest/PlayerController.java
+++ b/src/main/java/com/eight/mybatistest/PlayerController.java
@@ -1,6 +1,7 @@
 package com.eight.mybatistest;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -14,7 +15,7 @@ public class PlayerController {
     }
 
     @GetMapping("/player_list_database")
-    public List<Player> findAll() {
-        return playerMapper.findAll();
+    public List<Player> findByPlayers(@RequestParam int startsWith) {
+        return playerMapper.findByNumberStartingWith(startsWith);
     }
 }

--- a/src/main/java/com/eight/mybatistest/PlayerMapper.java
+++ b/src/main/java/com/eight/mybatistest/PlayerMapper.java
@@ -9,4 +9,7 @@ import java.util.List;
 public interface PlayerMapper {
     @Select("SELECT * FROM players ")
     List<Player> findAll();
+
+    @Select("SELECT * FROM players WHERE number LIKE CONCAT(#{id}, '%')")
+    List<Player> findByNumberStartingWith(int prefix);
 }


### PR DESCRIPTION
# 目的
mainブランチの「テーブルからレコードを全件取得するAPIの実装」に、idカラムをキーとして検索をかける<br>
クエリ文字列の追加を行いました。

# 実行結果
#### 【Postman】
①IDでstartsWith=1で検索をかけると背番号が１から始まる選手のレコードが取得されることを確認。<br>
  ↓1枚目:startsWith=1で検索を実行　HTTPステータス:200　2枚目:Content-Type:application/JSONを確認
![スクリーンショット (70)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/ea7ec820-69e7-44b9-97ca-6113e36aef93)
![スクリーンショット (71)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/a568dcc5-9f1d-4397-8519-d5c817135eaf)
<br><br>
②IDでstartsWith=2で検索をかけると該当するレコードが出力されないことを確認。<br>
![スクリーンショット (72)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/8298a16d-e8c4-4ef4-8995-6326aa685b6e)

#### 【cURL】
- cURLコマンド
curl --location 'http://localhost:8080/player_list_database?startsWith=1'
```sh
[
    {
        "id": 1,
        "name": "山岡泰輔",
        "number": 19,
        "prefecture": "広島県"
    },
    {
        "id": 2,
        "name": "宮城大弥",
        "number": 13,
        "prefecture": "沖縄県"
    }
]
```


