### PR TITLE
重複を許さないバリデーションとコンフリクトの追加

### DIFF
--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -4,7 +4,7 @@ CREATE TABLE players
     id INTEGER unsigned AUTO_INCREMENT,
     name VARCHAR(20) NOT NULL,
     position VARCHAR(15) NOT NULL,
-    uniform_number int(5) NOT NULL,
+    uniform_number VARCHAR(5) NOT NULL UNIQUE,
     prefecture VARCHAR(10) NOT NULL,
     PRIMARY KEY (id)
 );

--- a/src/main/java/com/eight/mybatistest/ExceptionControllerAdvise.java
+++ b/src/main/java/com/eight/mybatistest/ExceptionControllerAdvise.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,7 +37,7 @@ public class ExceptionControllerAdvise {
         e.getBindingResult().getFieldErrors().forEach(fieldError -> {
             Map<String, String> error = new HashMap<>();
             error.put("field", fieldError.getField());
-            error.put("message", fieldError.getDefaultMessage());
+            error.put("message", "文字を入力してください");
             errors.add(error);
         });
         ErrorResponse errorResponse =
@@ -66,5 +67,14 @@ public class ExceptionControllerAdvise {
         public List<Map<String, String>> getErrors() {
             return errors;
         }
+    }
+
+    @ExceptionHandler({SQLIntegrityConstraintViolationException.class})
+    public ResponseEntity<ErrorResponse> handleSQLIntegrityConstraintViolationException(SQLIntegrityConstraintViolationException e) {
+        Map<String, String> body = Map.of(
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "message", "その背番号は既に存在しています");
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/com/eight/mybatistest/ExceptionControllerAdvise.java
+++ b/src/main/java/com/eight/mybatistest/ExceptionControllerAdvise.java
@@ -72,9 +72,9 @@ public class ExceptionControllerAdvise {
     @ExceptionHandler({SQLIntegrityConstraintViolationException.class})
     public ResponseEntity<ErrorResponse> handleSQLIntegrityConstraintViolationException(SQLIntegrityConstraintViolationException e) {
         Map<String, String> body = Map.of(
-                "status", String.valueOf(HttpStatus.CONFLICT.value()),
-                "error", HttpStatus.CONFLICT.getReasonPhrase(),
-                "message", "その背番号は既に存在しています");
-        return new ResponseEntity(body, HttpStatus.CONFLICT);
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", "その背番号は既に使用されています");
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/eight/mybatistest/MybatisTestApplication.java
+++ b/src/main/java/com/eight/mybatistest/MybatisTestApplication.java
@@ -2,10 +2,11 @@ package com.eight.mybatistest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
 @SpringBootApplication
 public class MybatisTestApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(MybatisTestApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(MybatisTestApplication.class, args);
+    }
 }

--- a/src/main/java/com/eight/mybatistest/Player.java
+++ b/src/main/java/com/eight/mybatistest/Player.java
@@ -4,10 +4,10 @@ public class Player {
     private Integer id;
     private String name;
     private String position;
-    private int uniformNumber;
+    private String uniformNumber;
     private String prefecture;
 
-    public Player(Integer id, String name, String position, int uniformNumber, String prefecture) {
+    public Player(Integer id, String name, String position, String uniformNumber, String prefecture) {
         this.id = id;
         this.name = name;
         this.position = position;
@@ -15,7 +15,7 @@ public class Player {
         this.prefecture = prefecture;
     }
 
-    public Player(String name, String position, int uniformNumber, String prefecture) {
+    public Player(String name, String position, String uniformNumber, String prefecture) {
         this.id = null;
         this.name = name;
         this.position = position;
@@ -35,7 +35,7 @@ public class Player {
         return position;
     }
 
-    public int getUniformNumber() {
+    public String getUniformNumber() {
         return uniformNumber;
     }
 

--- a/src/main/java/com/eight/mybatistest/PlayerNumberConflictException.java
+++ b/src/main/java/com/eight/mybatistest/PlayerNumberConflictException.java
@@ -1,0 +1,7 @@
+package com.eight.mybatistest;
+
+public class PlayerNumberConflictException extends RuntimeException {
+    public PlayerNumberConflictException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/eight/mybatistest/PlayerRequest.java
+++ b/src/main/java/com/eight/mybatistest/PlayerRequest.java
@@ -2,17 +2,22 @@ package com.eight.mybatistest;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public class PlayerRequest {
     @NotBlank
+    @Pattern(regexp = "^[^\\u3000]*$")
     private String name;
     @NotBlank
+    @Pattern(regexp = "^[^\\u3000]*$")
     private String position;
-    @NotNull
-    private int uniformNumber;
     @NotBlank
+    @Pattern(regexp = "^[^\\u3000]*$")
+    private String uniformNumber;
+    @NotBlank
+    @Pattern(regexp = "^[^\\u3000]*$")
     private String prefecture;
-    public PlayerRequest(String name, String position, int uniformNumber, String prefecture) {
+    public PlayerRequest(String name, String position, String uniformNumber, String prefecture) {
         this.name = name;
         this.position = position;
         this.uniformNumber = uniformNumber;
@@ -25,7 +30,7 @@ public class PlayerRequest {
     public String getPosition() {
         return position;
     }
-    public int getUniformNumber() {
+    public String getUniformNumber() {
         return uniformNumber;
     }
     public String getPrefecture() {

--- a/src/main/java/com/eight/mybatistest/PlayerService.java
+++ b/src/main/java/com/eight/mybatistest/PlayerService.java
@@ -14,7 +14,7 @@ public class PlayerService {
         return this.playerMapper.findById(id).orElseThrow(() -> new PlayerNotFoundException("player not found"));
     }
 
-    public Player insert(String name, String position, int uniformNumber, String prefecture) {
+    public Player insert(String name, String position, String  uniformNumber, String prefecture) {
         Player player = new Player(name, position, uniformNumber, prefecture);
         playerMapper.insert(player);
         return player;


### PR DESCRIPTION
### 背番号が重複して登録されようとした際にバリデーションエラーを返す処理の追加。
- 事前に【背番号:10　大城滉二】を追加している状態。
![スクリーンショット (120)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/037d76e4-3c11-40e5-9b07-fd504ed678b9)

- 上記の状態で背番号が10番の選手が登録されようとした際に「その背番号は既に存在しています」とエラーが返り、コードは409:Conflictが返るようにハンドリング。
![スクリーンショット (116)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/f8170019-06c6-43d3-985d-dbd140b664d4)

### 前回のバリデーション漏れの修正。
### 半角・全角スペース、空欄の場合に「文字を入力してください」の表記が返るように設定。
- 空欄の場合
![スクリーンショット (117)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/375b8b3c-18ca-4942-8a9c-0446a776f3b8)

- 半角スペースの場合
![スクリーンショット (119)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/91bae52a-4fc1-43ff-8744-2b93e9fe768b)

- 全角スペースの場合
![スクリーンショット (118)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/682b99f0-a1a7-492a-9177-f62969879090)


また、背番号は【00】になる可能性もあるため、String型での定義に変更しています。

以上ご確認の程宜しく御願い致します。