### PR TITLE
Delete処理の際にidで見つからなかったときに404エラーを返すようにコードを修正

### DIFF
--- a/src/main/java/com/eight/mybatistest/PlayerController.java
+++ b/src/main/java/com/eight/mybatistest/PlayerController.java
@@ -1,9 +1,16 @@
 package com.eight.mybatistest;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -40,10 +47,10 @@ public class PlayerController {
     }
 
     @DeleteMapping("/players/{id}")
-    public ResponseEntity<Map<String, String>> deletePlayer(@PathVariable Integer id) {
-        playerService.delete(id);
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "player deleted");
-        return ResponseEntity.status(HttpStatus.OK).body(response);
+    public ResponseEntity<Map<String, String>> deletePlayerById(@PathVariable Integer id) {
+        playerService.deletePlayer(id);
+        Map<String, String> responseBody = new HashMap<>();
+        responseBody.put("message", "player deleted");
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/src/main/java/com/eight/mybatistest/PlayerController.java
+++ b/src/main/java/com/eight/mybatistest/PlayerController.java
@@ -1,10 +1,5 @@
 package com.eight.mybatistest;
 
-<<<<<<< HEAD
-import jakarta.servlet.http.HttpServletRequest;
-=======
-import jakarta.validation.Valid;
->>>>>>> f7fa9e9e9fba1519b0dee3e7dcb7c5724c9edc76
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/eight/mybatistest/PlayerController.java
+++ b/src/main/java/com/eight/mybatistest/PlayerController.java
@@ -38,4 +38,12 @@ public class PlayerController {
         response.put("message", "player updated");
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @DeleteMapping("/players/{id}")
+    public ResponseEntity<Map<String, String>> deletePlayer(@PathVariable Integer id) {
+        playerService.delete(id);
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "player deleted");
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/com/eight/mybatistest/PlayerMapper.java
+++ b/src/main/java/com/eight/mybatistest/PlayerMapper.java
@@ -1,8 +1,10 @@
 package com.eight.mybatistest;
 
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
@@ -23,4 +25,7 @@ public interface PlayerMapper {
 
     @Update("UPDATE players SET name = #{name}, position = #{position}, uniform_number = #{uniformNumber}, prefecture = #{prefecture} WHERE id = #{id}")
     void update(Player player);
+
+    @Delete("DELETE FROM players WHERE id = #{id}")
+    void delete(@Param("id") Integer id);
 }

--- a/src/main/java/com/eight/mybatistest/PlayerService.java
+++ b/src/main/java/com/eight/mybatistest/PlayerService.java
@@ -29,4 +29,8 @@ public class PlayerService {
         playerMapper.update(player);
         return player;
     }
+
+    public void delete(Integer id) {
+        playerMapper.delete(id);
+    }
 }

--- a/src/main/java/com/eight/mybatistest/PlayerService.java
+++ b/src/main/java/com/eight/mybatistest/PlayerService.java
@@ -30,7 +30,8 @@ public class PlayerService {
         return player;
     }
 
-    public void delete(Integer id) {
+    public void deletePlayer(Integer id) {
+        playerMapper.findById(id).orElseThrow(() -> new PlayerNotFoundException("Player not found"));
         playerMapper.delete(id);
     }
 }


### PR DESCRIPTION
### DELETE処理ですでに登録されている選手のデータを削除する処理の追加。
※一度プッシュした際にエラーハンドリングができていなかったのに気付いたため、あとから追加して再度プッシュしています。
- 前回存在していたID:6番の選手を削除した際のPostman。message:player deletedの画面とともにID6番の選手が削除されているのを確認。
![スクリーンショット (139)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/811050dd-373c-4dce-873d-773e8611936d)
![スクリーンショット (140)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/1af97e95-81f3-4252-987a-ece0165045ef)

- 存在しないIDを指定したときに（今回は100）、ハンドリングした内容でエラーメッセージが返ってくる（HTTPステータス:404　player not found）ことを確認。
![スクリーンショット (143)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/526dfb6f-288b-4ec9-ba12-9c5afadf7837)

PRが2回に分かれたため、file　changedが少し煩雑になってしまっている可能性がございます。
恐れ入りますがご確認賜りますようお願い申し上げます。

