### PR TITLE
PlayerMapperTestの実装

### DIFF
--- a/src/main/java/com/eight/mybatistest/Player.java
+++ b/src/main/java/com/eight/mybatistest/Player.java
@@ -36,7 +36,7 @@ public class Player {
                 Objects.equals(uniformNumber, player.uniformNumber) &&
                 Objects.equals(prefecture, player.prefecture);
     }
-
+    
     @Override
     public int hashCode() {
         return Objects.hash(name, position, uniformNumber, prefecture);

--- a/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
+++ b/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
@@ -40,6 +40,20 @@ class PlayerMapperTest {
     @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
     @Transactional
+    public void IDで指定した選手の情報が正しく取得されること() {
+        // テスト: IDが1のプレイヤーを検索
+        Optional<Player> playerOptional = playerMapper.findById(1);
+        assertThat(playerOptional).isPresent(); // プレイヤーが存在することを確認
+        assertThat(playerOptional.get().getName()).isEqualTo("山岡泰輔"); // 名前が正しいことを確認
+        assertThat(playerOptional.get().getPosition()).isEqualTo("投手"); // ポジションが正しいことを確認
+        assertThat(playerOptional.get().getUniformNumber()).isEqualTo("19"); // ユニフォーム番号が正しいことを確認
+        assertThat(playerOptional.get().getPrefecture()).isEqualTo("広島県"); // 都道府県が正しいことを確認
+    }
+
+    @Test
+    @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
     public void 選手のデータを新しく登録できること() {
         // 新しいプレイヤーオブジェクトを作成
         Player player = new Player();
@@ -66,56 +80,34 @@ class PlayerMapperTest {
     @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
     @Transactional
-    public void 登録された選手のデータが正しく更新できること() {
-        // 新しいプレイヤーオブジェクトを作成してデータベースに挿入
-        Player player = new Player();
-        player.setName("廣岡大志");
-        player.setPosition("内野手");
-        player.setUniformNumber("30");
-        player.setPrefecture("大阪府");
-        playerMapper.insert(player);
-
-        // 更新する情報を設定
-        player.setName("横山聖哉");
-        player.setPosition("内野手");
-        player.setUniformNumber("34");
-        player.setPrefecture("長野県");
-
-        // Updateを実行
+    public void IDで指定した選手の情報が正しく更新されること() {
+        // テスト: IDが2のプレイヤーの情報を更新
+        Player player = new Player(2, "阿部翔太", "投手", "20", "大阪府");
         playerMapper.update(player);
 
         // 更新後のプレイヤーを検索して取得
-        Optional<Player> updatedPlayerOptional = playerMapper.findById(player.getId());
-        assertThat(updatedPlayerOptional).isPresent(); // 更新後のプレイヤーが存在することを確認
-
-        Player updatedPlayer = updatedPlayerOptional.get();
-        assertThat(updatedPlayer.getName()).isEqualTo(player.getName()); // 名前が一致することを確認
-        assertThat(updatedPlayer.getPosition()).isEqualTo(player.getPosition()); // ポジションが一致することを確認
-        assertThat(updatedPlayer.getUniformNumber()).isEqualTo(player.getUniformNumber()); // ユニフォーム番号が一致することを確認
-        assertThat(updatedPlayer.getPrefecture()).isEqualTo(player.getPrefecture()); // 都道府県が一致することを確認
+        Optional<Player> updatedPlayerOptional = playerMapper.findById(2);
+        assertThat(updatedPlayerOptional).isPresent(); // プレイヤーが存在することを確認
+        assertThat(updatedPlayerOptional.get().getName()).isEqualTo("阿部翔太"); // 名前が更新されていることを確認
+        assertThat(updatedPlayerOptional.get().getPosition()).isEqualTo("投手"); // ポジションが更新されていることを確認
+        assertThat(updatedPlayerOptional.get().getUniformNumber()).isEqualTo("20"); // ユニフォーム番号が更新されていることを確認
+        assertThat(updatedPlayerOptional.get().getPrefecture()).isEqualTo("大阪府"); // 都道府県が更新されていることを確認
     }
 
     @Test
     @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
     @Transactional
-    public void 登録された選手のデータが削除できること() {
-        // 新しいプレイヤーオブジェクトを作成してデータベースに挿入
-        Player player = new Player();
-        player.setName("鈴木博志");
-        player.setPosition("投手");
-        player.setUniformNumber("66");
-        player.setPrefecture("静岡県");
-        playerMapper.insert(player);
+    public void IDで指定した選手の情報が削除されること() {
+        // テスト: IDが3のプレイヤーを削除
+        playerMapper.delete(3);
 
-        // プレイヤーのIDを取得
-        Integer playerId = player.getId();
-
-        // Deleteを実行
-        playerMapper.delete(playerId);
-
-        // Delete後のプレイヤーを検索して取得
-        Optional<Player> deletedPlayerOptional = playerMapper.findById(playerId);
+        // プレイヤーが削除されたことを確認
+        Optional<Player> deletedPlayerOptional = playerMapper.findById(3);
         assertThat(deletedPlayerOptional).isEmpty(); // プレイヤーが存在しないことを確認
+
+        // プレイヤーが削除された後のリストのサイズが1つ減少していることを確認
+        List<Player> playersAfterDelete = playerMapper.findAll();
+        assertThat(playersAfterDelete.size()).isEqualTo(5); // プレイヤーの数が5であることを確認
     }
 }

--- a/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
+++ b/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,5 +34,88 @@ class PlayerMapperTest {
                         new Player("紅林弘太郎", "内野手", "24", "静岡県"),
                         new Player("T-岡田", "外野手", "55", "大阪府")
                 );
+    }
+
+    @Test
+    @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    public void 選手のデータを新しく登録できること() {
+        // 新しいプレイヤーオブジェクトを作成
+        Player player = new Player();
+        player.setName("西野真弘");
+        player.setPosition("内野手");
+        player.setUniformNumber("5");
+        player.setPrefecture("東京都");
+
+        // Insertを実行
+        playerMapper.insert(player);
+
+        // InsertされたプレイヤーをIDで検索して取得
+        Optional<Player> insertedPlayerOptional = playerMapper.findById(player.getId());
+        assertThat(insertedPlayerOptional).isPresent(); // Insertされたプレイヤーが存在することを確認
+
+        Player insertedPlayer = insertedPlayerOptional.get();
+        assertThat(insertedPlayer.getName()).isEqualTo(player.getName()); // 名前が一致することを確認
+        assertThat(insertedPlayer.getPosition()).isEqualTo(player.getPosition()); // ポジションが一致することを確認
+        assertThat(insertedPlayer.getUniformNumber()).isEqualTo(player.getUniformNumber()); // ユニフォーム番号が一致することを確認
+        assertThat(insertedPlayer.getPrefecture()).isEqualTo(player.getPrefecture()); // 都道府県が一致することを確認
+    }
+
+    @Test
+    @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    public void 登録された選手のデータが正しく更新できること() {
+        // 新しいプレイヤーオブジェクトを作成してデータベースに挿入
+        Player player = new Player();
+        player.setName("廣岡大志");
+        player.setPosition("内野手");
+        player.setUniformNumber("30");
+        player.setPrefecture("大阪府");
+        playerMapper.insert(player);
+
+        // 更新する情報を設定
+        player.setName("横山聖哉");
+        player.setPosition("内野手");
+        player.setUniformNumber("34");
+        player.setPrefecture("長野県");
+
+        // Updateを実行
+        playerMapper.update(player);
+
+        // 更新後のプレイヤーを検索して取得
+        Optional<Player> updatedPlayerOptional = playerMapper.findById(player.getId());
+        assertThat(updatedPlayerOptional).isPresent(); // 更新後のプレイヤーが存在することを確認
+
+        Player updatedPlayer = updatedPlayerOptional.get();
+        assertThat(updatedPlayer.getName()).isEqualTo(player.getName()); // 名前が一致することを確認
+        assertThat(updatedPlayer.getPosition()).isEqualTo(player.getPosition()); // ポジションが一致することを確認
+        assertThat(updatedPlayer.getUniformNumber()).isEqualTo(player.getUniformNumber()); // ユニフォーム番号が一致することを確認
+        assertThat(updatedPlayer.getPrefecture()).isEqualTo(player.getPrefecture()); // 都道府県が一致することを確認
+    }
+
+    @Test
+    @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    public void 登録された選手のデータが削除できること() {
+        // 新しいプレイヤーオブジェクトを作成してデータベースに挿入
+        Player player = new Player();
+        player.setName("鈴木博志");
+        player.setPosition("投手");
+        player.setUniformNumber("66");
+        player.setPrefecture("静岡県");
+        playerMapper.insert(player);
+
+        // プレイヤーのIDを取得
+        Integer playerId = player.getId();
+
+        // Deleteを実行
+        playerMapper.delete(playerId);
+
+        // Delete後のプレイヤーを検索して取得
+        Optional<Player> deletedPlayerOptional = playerMapper.findById(playerId);
+        assertThat(deletedPlayerOptional).isEmpty(); // プレイヤーが存在しないことを確認
     }
 }

--- a/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
+++ b/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MybatisTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -43,11 +44,10 @@ class PlayerMapperTest {
     public void IDで指定した選手の情報が正しく取得されること() {
         // テスト: IDが1のプレイヤーを検索
         Optional<Player> playerOptional = playerMapper.findById(1);
-        assertThat(playerOptional).isPresent(); // プレイヤーが存在することを確認
-        assertThat(playerOptional.get().getName()).isEqualTo("山岡泰輔"); // 名前が正しいことを確認
-        assertThat(playerOptional.get().getPosition()).isEqualTo("投手"); // ポジションが正しいことを確認
-        assertThat(playerOptional.get().getUniformNumber()).isEqualTo("19"); // ユニフォーム番号が正しいことを確認
-        assertThat(playerOptional.get().getPrefecture()).isEqualTo("広島県"); // 都道府県が正しいことを確認
+        assertTrue(playerOptional.isPresent()); // プレイヤーが存在することを確認
+
+        Player expectedPlayer = new Player(1, "山岡泰輔", "投手", "19", "広島県");
+        assertThat(playerOptional.get()).isEqualTo(expectedPlayer);
     }
 
     @Test
@@ -67,13 +67,9 @@ class PlayerMapperTest {
 
         // InsertされたプレイヤーをIDで検索して取得
         Optional<Player> insertedPlayerOptional = playerMapper.findById(player.getId());
-        assertThat(insertedPlayerOptional).isPresent(); // Insertされたプレイヤーが存在することを確認
+        assertTrue(insertedPlayerOptional.isPresent()); // Insertされたプレイヤーが存在することを確認
 
-        Player insertedPlayer = insertedPlayerOptional.get();
-        assertThat(insertedPlayer.getName()).isEqualTo(player.getName()); // 名前が一致することを確認
-        assertThat(insertedPlayer.getPosition()).isEqualTo(player.getPosition()); // ポジションが一致することを確認
-        assertThat(insertedPlayer.getUniformNumber()).isEqualTo(player.getUniformNumber()); // ユニフォーム番号が一致することを確認
-        assertThat(insertedPlayer.getPrefecture()).isEqualTo(player.getPrefecture()); // 都道府県が一致することを確認
+        assertThat(insertedPlayerOptional.get()).isEqualTo(player);
     }
 
     @Test
@@ -87,11 +83,9 @@ class PlayerMapperTest {
 
         // 更新後のプレイヤーを検索して取得
         Optional<Player> updatedPlayerOptional = playerMapper.findById(2);
-        assertThat(updatedPlayerOptional).isPresent(); // プレイヤーが存在することを確認
-        assertThat(updatedPlayerOptional.get().getName()).isEqualTo("阿部翔太"); // 名前が更新されていることを確認
-        assertThat(updatedPlayerOptional.get().getPosition()).isEqualTo("投手"); // ポジションが更新されていることを確認
-        assertThat(updatedPlayerOptional.get().getUniformNumber()).isEqualTo("20"); // ユニフォーム番号が更新されていることを確認
-        assertThat(updatedPlayerOptional.get().getPrefecture()).isEqualTo("大阪府"); // 都道府県が更新されていることを確認
+        assertTrue(updatedPlayerOptional.isPresent()); // プレイヤーが存在することを確認
+
+        assertThat(updatedPlayerOptional.get()).isEqualTo(player);
     }
 
     @Test

--- a/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
+++ b/src/test/java/com/eight/mybatistest/PlayerMapperTest.java
@@ -1,0 +1,37 @@
+package com.eight.mybatistest;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PlayerMapperTest {
+    @Autowired
+    PlayerMapper playerMapper;
+
+    @Test
+    @Sql(scripts = {"classpath:/sqlannotation/delete-players.sql", "classpath:/sqlannotation/insert-players.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void 全てのプレイヤーの情報が取得できること() {
+        List<Player> players = playerMapper.findAll();
+        assertThat(players)
+                .hasSize(6)
+                .contains(
+                        new Player("山岡泰輔", "投手", "19", "広島県"),
+                        new Player("宮城大弥", "投手", "13", "沖縄県"),
+                        new Player("頓宮裕馬", "捕手", "44", "岡山県"),
+                        new Player("宗佑馬", "内野手", "6", "東京都"),
+                        new Player("紅林弘太郎", "内野手", "24", "静岡県"),
+                        new Player("T-岡田", "外野手", "55", "大阪府")
+                );
+    }
+}

--- a/src/test/resources/sqlannotation/delete-players.sql
+++ b/src/test/resources/sqlannotation/delete-players.sql
@@ -1,0 +1,1 @@
+DELETE FROM players;

--- a/src/test/resources/sqlannotation/insert-players.sql
+++ b/src/test/resources/sqlannotation/insert-players.sql
@@ -1,13 +1,3 @@
-DROP TABLE IF EXISTS players;
-CREATE TABLE players
-(
-    id INTEGER unsigned AUTO_INCREMENT,
-    name VARCHAR(20) NOT NULL,
-    position VARCHAR(15) NOT NULL,
-    uniform_number VARCHAR(5) NOT NULL UNIQUE,
-    prefecture VARCHAR(10) NOT NULL,
-    PRIMARY KEY (id)
-);
 INSERT INTO players (name,position,uniform_number,prefecture)
 VALUES ("山岡泰輔","投手","19","広島県");
 INSERT INTO players (name,position,uniform_number,prefecture)

--- a/src/test/resources/sqlannotation/insert-players.sql
+++ b/src/test/resources/sqlannotation/insert-players.sql
@@ -1,12 +1,12 @@
 INSERT INTO players (name,position,uniform_number,prefecture)
-VALUES ("山岡泰輔","投手","19","広島県");
+VALUES ("山岡泰輔", "投手", "19", "広島県");
 INSERT INTO players (name,position,uniform_number,prefecture)
-VALUES ("宮城大弥","投手","13","沖縄県");
+VALUES ("宮城大弥", "投手", "13", "沖縄県");
 INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES ("頓宮裕馬","捕手","44","岡山県");
+VALUES ("頓宮裕馬", "捕手", "44", "岡山県");
 INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES("宗佑馬","内野手","6","東京都");
+VALUES("宗佑馬", "内野手", "6", "東京都");
 INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES("紅林弘太郎","内野手","24","静岡県");
+VALUES("紅林弘太郎", "内野手", "24", "静岡県");
 INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES("T-岡田","外野手","55","大阪府");
+VALUES("T-岡田", "外野手", "55", "大阪府");

--- a/src/test/resources/sqlannotation/insert-players.sql
+++ b/src/test/resources/sqlannotation/insert-players.sql
@@ -1,12 +1,12 @@
-INSERT INTO players (name,position,uniform_number,prefecture)
-VALUES ("山岡泰輔", "投手", "19", "広島県");
-INSERT INTO players (name,position,uniform_number,prefecture)
-VALUES ("宮城大弥", "投手", "13", "沖縄県");
-INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES ("頓宮裕馬", "捕手", "44", "岡山県");
-INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES("宗佑馬", "内野手", "6", "東京都");
-INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES("紅林弘太郎", "内野手", "24", "静岡県");
-INSERT INTO players(name,position,uniform_number,prefecture)
-VALUES("T-岡田", "外野手", "55", "大阪府");
+INSERT INTO players (id,name,position,uniform_number,prefecture)
+VALUES (1,"山岡泰輔", "投手", "19", "広島県");
+INSERT INTO players (id,name,position,uniform_number,prefecture)
+VALUES (2,"宮城大弥", "投手", "13", "沖縄県");
+INSERT INTO players(id,name,position,uniform_number,prefecture)
+VALUES (3,"頓宮裕馬", "捕手", "44", "岡山県");
+INSERT INTO players(id,name,position,uniform_number,prefecture)
+VALUES (4,"宗佑馬", "内野手", "6", "東京都");
+INSERT INTO players(id,name,position,uniform_number,prefecture)
+VALUES (5,"紅林弘太郎", "内野手", "24", "静岡県");
+INSERT INTO players(id,name,position,uniform_number,prefecture)
+VALUES (6,"T-岡田", "外野手", "55", "大阪府");


### PR DESCRIPTION
**【2024/5/24修正】**
### Mapperに対するテストコードを実装しています。
### 全件取得、選手データの登録、選手データの変更、選手データの削除ができるかを検証しています。
- テストが全件通っていることを確認。
![スクリーンショット (157)](https://github.com/Kazuyuki-Kato/mybatisexam/assets/154575590/6f2c75da-73b5-4ab0-9b78-9fd5e4d7993d)



